### PR TITLE
Build container image and push to GAR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,67 @@
+name: Docker build & push
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - '*'
+jobs:
+  docker:
+    name: Docker Images
+    runs-on: ubuntu-latest
+    environment: build
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY}}/${{ vars.GAR_NAME }}
+          tags: |
+            type=semver,pattern={{raw}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Generate version.json
+        shell: bash
+        run: |
+          printf '{"commit":"%s","version":"%s","source":"https://github.com/%s","build":"%s/%s/actions/runs/%s"}\n' \
+          "$GITHUB_SHA" \
+          "$GITHUB_REF_NAME" \
+          "$GITHUB_REPOSITORY" \
+          "$GITHUB_SERVER_URL" \
+          "$GITHUB_REPOSITORY" \
+          "$GITHUB_RUN_ID" | tee version.json
+
+      - id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          service_account: artifact-writer@${{ vars.GCP_PROJECT_ID}}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          sbom: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: .


### PR DESCRIPTION
This PR adds a GitHub action to build and push the container image to GAR.

Before this PR gets merged, you'll need to:
- Review, apply, and merge https://github.com/mozilla-it/webservices-infra/pull/3439 .
- Add a new Actions environment called `build` in this repository
- Add the following variables to the `build` environment:
  - `GAR_LOCATION` `us`
  - `GAR_NAME` `webcompat`
  - `GAR_REPOSITORY` `webcompat-prod`
  - `GCP_PROJECT_ID` `moz-fx-webcompat-prod`